### PR TITLE
Update schedule-coldkey-swap.md

### DIFF
--- a/docs/keys/schedule-coldkey-swap.md
+++ b/docs/keys/schedule-coldkey-swap.md
@@ -20,8 +20,8 @@ The schedule coldkey swap feature works as follows:
 
 - The schedule coldkey swap feature enables you to schedule the swapping of source coldkey to a destination coldkey. If you feel your existing coldkey is potentially compromised, then use this feature to schedule a swap to a destination coldkey.
 - When you use this feature, it will not immediately swap your coldkeys and swap your TAO funds from the source coldkey to the destination coldkey. It will only schedule the swap event.
-- All scheduled coldkey swaps will be executed on-chain. **Your scheduled coldkey swap will execute on the mainnet exactly 5 days after you successfully scheduled the coldkey swap using the method described in this document.**
-- The source coldkey you used in this method will be locked when you schedule the swap. After the 5-day period is elapsed your original coldkey will be unlocked entirely.
+- All scheduled coldkey swaps will be executed on-chain. **Your scheduled coldkey swap will execute on the mainnet 7200 blocks (approximately 24 hours) after you successfully scheduled the coldkey swap using the method described in this document.**
+- The source coldkey you used in this method will be locked when you schedule the swap. After the 7200-block period is elapsed your original coldkey will be unlocked entirely.
 - **Cost**: The cost of this coldkey swap transaction is 0.1 TAO. This must be available in your source coldkey.
 - Any subnet ownership from your source coldkey will move to the destination coldkey.
 - The delegated stake will be transferred from your source coldkey to the destination coldkey.
@@ -99,4 +99,4 @@ Scroll down to the bottom of the page and click on the **Submit Transaction** bu
 
 ## Verify
 
-Your scheduled coldkey swap will execute on the mainnet 5 days after you successfully scheduled the coldkey swap using the above method. Check your destination coldkey after 5 days to verify.
+Your scheduled coldkey swap will execute on the mainnet 7200 blocks after you successfully scheduled the coldkey swap using the above method. Check your destination coldkey after approximately 24 hours to verify.


### PR DESCRIPTION
Coldkey swaps now execute in 7200 blocks; I've updated the doc to reflect this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update docs to reflect coldkey swaps execute after 7200 blocks (~24h) with corresponding lock period and verification steps.
> 
> - **Docs** (`docs/keys/schedule-coldkey-swap.md`):
>   - Update swap execution delay from 5 days to 7200 blocks (~24h).
>   - Adjust source coldkey lock/unlock period to 7200 blocks.
>   - Revise Verify section to check after ~24 hours.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714bbc2f4d308accdc3214dec5a07c6a2b794e95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->