### PR TITLE
Remove header links from sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -42,7 +42,6 @@ const sidebars = {
     {
       type: "category",
       label: "Understand Bittensor",
-      link: { type: "doc", id: "learn/introduction" },
       collapsible: true,
       collapsed: true,
       items: [
@@ -91,7 +90,6 @@ const sidebars = {
       label: "Staking/Delegation",
       collapsible: true,
       collapsed: true,
-      link: { type: "doc", id: "staking-and-delegation/delegation" },
       items: [
         "staking-and-delegation/delegation",
         "staking-and-delegation/stakers-btcli-guide",


### PR DESCRIPTION
This is in relation to issue #113 - some next pages links display the wrong link, and instead link back to themselves.

It seems like the issue is due to the header links for each section which is affecting the generated pagination, but I'm not sure if this is the desired fix. 

If instead header links are preferred, I think the solution is to remove the link with the `items` list instead.

Jack