### PR TITLE
Emissions - mention the word "Taoflow"

### DIFF
--- a/docs/learn/emissions.md
+++ b/docs/learn/emissions.md
@@ -10,8 +10,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 Emission is the economic heartbeat of Bittensor—the process that continuously distributes newly created [TAO](../resources/glossary.md#tao-τ) and subnet-specific alpha tokens to network participants who contribute value through [mining](../resources/glossary.md#subnet-miner), [validation](../resources/glossary.md#validator), [staking](../resources/glossary.md#staking), and [subnet creation](../resources/glossary.md#subnet-creator).
 
 
-:::tip Flow-Based Emissions Now Active
-**As of November 2025**: Bittensor has transitioned to a **flow-based model** for determining how TAO emissions are distributed across subnets. Emissions are now based on net TAO inflows due to staking activity, rather than token prices as previously.
+:::tip Flow-Based Emissions ("Taoflow") Now Active
+**As of November 2025**: Bittensor has transitioned to a **flow-based model** ("Taoflow") for determining how TAO emissions are distributed across subnets. Emissions are now based on net TAO inflows due to staking activity, rather than token prices as previously.
 
 See:
 - [How flow-based injection works](#tao-reserve-injection)


### PR DESCRIPTION
Since the word "Taoflow" is going out on social media, but isn't specifically referencing that this is about emissions, it's important to get the buzzword into the docs, so that if someone searches on it, they get to the right page.