### PR TITLE
CLI parsing on Bittensor SDK

### DIFF
--- a/docs/local-build/mine-validate.md
+++ b/docs/local-build/mine-validate.md
@@ -224,7 +224,7 @@ Begin by starting the miner process to produce and submit work to the subnet. Th
 To start the miner, run the following Python script in the `subnet-template` directory:
 
 ```sh
-python miner.py \
+BT_NO_PARSE_CLI_ARGS=0 python miner.py \
   --wallet.name WALLET_NAME \
   --wallet.hotkey HOTKEY \
   --netuid NETUID \
@@ -239,7 +239,7 @@ The script launches an Axon server on port `8901`, which the miner uses to recei
 To start the validator process, run the following Python script in the `subnet-template` directory:
 
 ```sh
-python validator.py \
+BT_NO_PARSE_CLI_ARGS=0 python validator.py \
   --wallet.name WALLET_NAME \
   --wallet.hotkey HOTKEY \
   --netuid NETUID \

--- a/docs/sdk/env-vars.md
+++ b/docs/sdk/env-vars.md
@@ -30,7 +30,7 @@ The SDK uses `False ` if the variable is not set.
 
 ### `BT_NO_PARSE_CLI_ARGS`
 
-When `BT_NO_PARSE_CLI_ARGS=1` (default), this disables CLI argument parsing on the SDK. Setting its value to `false` or `0` enables CLI argument parsing and allows the SDK to read command-line arguments.
+When `BT_NO_PARSE_CLI_ARGS=1` (default), this disables CLI argument parsing on the SDK. Setting its value to `false` or `0` enables CLI argument parsing and allows the SDK to read additional command-line arguments.
 
 ## Subtensor
 

--- a/docs/sdk/env-vars.md
+++ b/docs/sdk/env-vars.md
@@ -28,6 +28,10 @@ Allows Bittensor to be run in read-only systems.<br/>
 When set to `1`, forces the use of `PyTorch` instead of NumPy for certain operations.<br/>
 The SDK uses `False ` if the variable is not set.
 
+### `BT_NO_PARSE_CLI_ARGS`
+
+When `BT_NO_PARSE_CLI_ARGS=1` (default), this disables CLI argument parsing on the SDK. Setting its value to `false` or `0` enables CLI argument parsing and allows the SDK to read command-line arguments.
+
 ## Subtensor
 
 ### `BT_SUBTENSOR_CHAIN_ENDPOINT`

--- a/docs/sdk/migration-guide.md
+++ b/docs/sdk/migration-guide.md
@@ -1024,24 +1024,28 @@ BT_SUBTENSOR_NETWORK=local
 - `BT_CHAIN_ENDPOINT` → `BT_SUBTENSOR_CHAIN_ENDPOINT`
 - `BT_NETWORK` → `BT_SUBTENSOR_NETWORK`
 
-### Disabling CLI Argument Parsing
+### Enabling CLI Argument Parsing
 
-If your script uses the SDK and receives unwanted `--config` or other CLI parameters:
+CLI argument passing is disabled by default. Therefore, if your script uses the SDK and receives unwanted `--config` or other CLI parameters, you must explicitly enable this by using the `BT_NO_PARSE_CLI_ARGS`.
 
-```python
-# Set environment variable to disable config processing:
-BT_NO_PARSE_CLI_ARGS=1  # or: true, yes, on
+Set environment variable to `0`, `false`, `no`, or `off` to enable parsing as shown:
 
-# In code:
+```bash
+BT_NO_PARSE_CLI_ARGS=0 python your_script.py --logging.debug
+```
+
+Or in code:
+
+```py
 import os
-os.environ['BT_NO_PARSE_CLI_ARGS'] = '1'
+os.environ['BT_NO_PARSE_CLI_ARGS'] = '0'
 
 from bittensor import Subtensor
-# CLI args will no longer be processed
+# CLI arguments will now be processed by the SDK
 ```
 
 :::tip
-When `BT_NO_PARSE_CLI_ARGS` is set, the SDK skips CLI parsing entirely and falls back to default configuration values defined in `bittensor.core.settings.DEFAULTS` for all configuration options across the SDK. This is useful when embedding the SDK in applications that manage their own configuration.
+CLI parsing is disabled by default (`BT_NO_PARSE_CLI_ARGS=1`). This means that the SDK skips CLI parsing entirely and falls back to default configuration values defined in `bittensor.core.settings.DEFAULTS` for all configuration options across the SDK. This is useful when embedding the SDK in applications that manage their own configuration.
 :::
 
 ## Metagraph Changes


### PR DESCRIPTION
Updated docs to reflect new SDK behavior on CLI parsing default.

[Related Bittensor SDK PR](https://github.com/latent-to/bittensor/pull/3347)