### PR TITLE
docs: add OmniRisk to Ecosystem Tools in community-links

### DIFF
--- a/docs/resources/community-links.md
+++ b/docs/resources/community-links.md
@@ -31,3 +31,7 @@ You can also explore Bittensor's many Subnets and find links to their websites a
 - **[BTCLI](https://github.com/opentensor/btcli)**, the Bittensor CLI
 - The **[Bittensor SDK](https://github.com/opentensor/bittensor)**
 - **[Subtensor](https://github.com/opentensor/subtensor)**, Bittensor's substrate blockchain
+
+## Ecosystem Tools
+
+- **[OmniRisk](https://omnirisk.io)** — Real-time risk intelligence for the Bittensor ecosystem. OmniScore rates subnet health across emission stability, validator concentration, and liquidity depth, helping TAO stakers and dTAO participants assess subnet exposure before allocating stake.


### PR DESCRIPTION
## Summary

Adds **OmniRisk** to a new *Ecosystem Tools* section in `docs/resources/community-links.md`.

OmniRisk is a real-time risk intelligence platform built for the Bittensor ecosystem. OmniScore rates subnet health across emission stability, validator concentration, and liquidity depth — giving TAO stakers and dTAO participants a quantitative signal for evaluating subnet exposure before allocating stake.

**Website:** https://omnirisk.io

## Why this belongs here

The community-links page covers essential tools for navigating the Bittensor network. Risk intelligence and subnet health scoring are a natural complement to the existing block explorers and wallet listings — OmniRisk helps users make informed stake allocation decisions across subnets.

## Change

- Added a new `## Ecosystem Tools` section at the bottom of `community-links.md`
- One entry: OmniRisk with a one-line description of OmniScore's function