### PR TITLE
Add Neuralteq community link

### DIFF
--- a/docs/resources/community-links.md
+++ b/docs/resources/community-links.md
@@ -20,6 +20,10 @@ You can also explore Bittensor's many Subnets and find links to their websites a
 - **[Taostats](https://taostats.io/)**
 - **[Taomarketcap](https://taomarketcap.com/)**
 
+## Research and Market Tools
+
+- **[Neuralteq](https://neuralteq.com/)** - Non-custodial Bittensor dTAO research and workflow platform for subnet market data, portfolio tracking, staking tools, orders, baskets, and swaps.
+
 ## Wallet Applications
 
 - **[Bittensor Wallet](https://www.tao.com/)** - Recommended (maintained by Tao.com).


### PR DESCRIPTION
## Summary\n\nAdds Neuralteq to the Bittensor Community Links page under a small Research and Market Tools section. Neuralteq is a non-custodial Bittensor dTAO research and workflow platform for subnet market data, portfolio tracking, staking tools, orders, baskets, and swaps.\n\n## Link\n\nhttps://neuralteq.com/